### PR TITLE
Changed monolog dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pulse00/monolog-parser",
     "description": "A parser for monolog log entries",
     "require": {
-        "monolog/monolog": "dev-master"
+        "monolog/monolog": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Any reason you are depending on dev-master instead of 1.\* stable releases? It prohibits me from using this package in my projects :-) 
