### PR TITLE
add ext-json to composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "pulse00/monolog-parser",
     "description": "A parser for monolog log entries",
     "require": {
+        "ext-json": "*",
         "monolog/monolog": "1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Because the package will throw a fatal error without it.