### PR TITLE
Allow Monolog v2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pulse00/monolog-parser",
     "description": "A parser for monolog log entries",
     "require": {
-        "monolog/monolog": "1.*"
+        "monolog/monolog": "1.*|2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"


### PR DESCRIPTION
Hi,

Allowing both v1 and v2 of monolog will pass your tests.

Fixes #12 